### PR TITLE
show/hide button for many LOs

### DIFF
--- a/src/main/resources/static/js/results.js
+++ b/src/main/resources/static/js/results.js
@@ -93,4 +93,19 @@ function downloadCsvFile(csvData){
     document.body.removeChild(downloadLink);
 }
 
+/*
+*   If more than 3 Learning Outcomes for a course, toggles show hide of remaining
+ */
+function showLOs(classVal) {
+    if($("#" + classVal).text() == "Show More!") {
+        $("." + classVal).css("display", "block");
+        $("#" + classVal).text("Show Less!");
+    }
+    else {
+        $("." + classVal).css("display", "none");
+        $("#" + classVal).text("Show More!");
+    }
+
+}
+
 

--- a/src/main/resources/templates/fragments/results.html
+++ b/src/main/resources/templates/fragments/results.html
@@ -75,17 +75,22 @@
                     </thead>
                     <tbody>
                     <tr th:each = "course: ${courses}">
-                        <!--<th th:text = "${course.id}"></th>-->
                         <td th:text = "${course.name}"></td>
                         <td th:text = "${course.code}"></td>
-                        <!--<td>-->
-                            <!--<span th:each="allPrograms: ${course.programs}" th:utext = "${allPrograms.name + '&lt;br /&gt;'} "></span>-->
-                        <!--</td>-->
                         <td>
-                            <span th:each="allOutcomes: ${course.learningOutcomes}" th:utext="${allOutcomes.category.name + '&lt;br /&gt;'}"></span>
+                            <span th:each="allOutcomes, iter : ${course.learningOutcomes}">
+                                <span th:if="${iter.index <= 2}" th:utext="${allOutcomes.category.name + '&lt;br /&gt;'}"></span>
+                                <span th:unless="${iter.index <= 2}" th:class="${course.code}" style="display: none;" th:utext="${allOutcomes.category.name + '&lt;br /&gt;'}"></span>
+                            </span>
                         </td>
                         <td>
-                            <span th:each="allOutcomes: ${course.learningOutcomes}" th:utext = "${allOutcomes.name + '&lt;br /&gt;'}"></span>
+                            <span th:each="allOutcomes, iter : ${course.learningOutcomes}">
+                                <span th:if="${iter.index <= 2}" th:utext = "${allOutcomes.name + '&lt;br /&gt;'}"></span>
+                                <span th:unless="${iter.index <= 2}" th:class="${course.code}" style="display: none;" th:utext = "${allOutcomes.name + '&lt;br /&gt;'}"></span>
+                            </span>
+                            <span th:if="${#lists.size(course.learningOutcomes) > 2}">
+                                    <button th:id="${course.code}" class="btn btn-info" style="padding-top: 5px;" onclick="showLOs(this.getAttribute('id'))">Show More!</button>
+                            </span>
                         </td>
                     </tr>
                     </tbody>

--- a/src/main/resources/templates/fragments/results.html
+++ b/src/main/resources/templates/fragments/results.html
@@ -88,7 +88,7 @@
                                 <span th:if="${iter.index <= 2}" th:utext = "${allOutcomes.name + '&lt;br /&gt;'}"></span>
                                 <span th:unless="${iter.index <= 2}" th:class="${course.code}" style="display: none;" th:utext = "${allOutcomes.name + '&lt;br /&gt;'}"></span>
                             </span>
-                            <span th:if="${#lists.size(course.learningOutcomes) > 2}">
+                            <span th:if="${#lists.size(course.learningOutcomes) > 3}">
                                     <button th:id="${course.code}" class="btn btn-info" style="padding-top: 5px;" onclick="showLOs(this.getAttribute('id'))">Show More!</button>
                             </span>
                         </td>


### PR DESCRIPTION
If there are more than 3 LOs, a show more buttons appears to toggle the remaining LOs. I put in test LOs in data.sql to show the feature, but I have not included them in the commit. 

![image](https://user-images.githubusercontent.com/15951317/55282302-b35bc580-5317-11e9-8120-3ac4a9970c0c.png)

After clicking: 
![image](https://user-images.githubusercontent.com/15951317/55282305-bc4c9700-5317-11e9-883a-8bfaa05c60bd.png)

(@andrewdlqnguyen and @adamstaples, added y'all in case this is something you want to apply to the admin page as well)

Closes #65 